### PR TITLE
[add]create follow_func

### DIFF
--- a/app/assets/stylesheets/relationships.scss
+++ b/app/assets/stylesheets/relationships.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the relationships controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -1,0 +1,31 @@
+class RelationshipsController < ApplicationController
+  before_action :set_user
+
+  def create
+    following = current_user.follow(@user)
+    if following.save
+      flash[:success] = 'ユーザーをフォローしました'
+      redirect_to @user
+    else
+      flash.now[:alert] = 'ユーザーのフォローに失敗しました'
+      redirect_to @user
+    end
+  end
+
+  def destroy
+    following = current_user.unfollow(@user)
+    if following.destroy
+      flash[:success] = 'ユーザーのフォローを解除しました'
+      redirect_to @user
+    else
+      flash.now[:alert] = 'ユーザーのフォロー解除に失敗しました'
+      redirect_to @user
+    end
+  end
+
+  private
+  
+  def set_user
+    @user = User.find(params[:relationship][:follow_id])
+  end
+end

--- a/app/helpers/relationships_helper.rb
+++ b/app/helpers/relationships_helper.rb
@@ -1,0 +1,2 @@
+module RelationshipsHelper
+end

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -1,0 +1,7 @@
+class Relationship < ApplicationRecord
+  belongs_to :user
+  belongs_to :follow, class_name: 'User'
+  
+  validates :user_id, presence: true
+  validates :follow_id, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,39 @@
 class User < ApplicationRecord
+
+  # ================================
+  # リレーション参考文献：
+  # https://qiita.com/mitsumitsu1128/items/e41e2ff37f143db81897
+  # ================================
+
+  has_many :relationships
+  # followingsクラス（model）は存在しないため、through: :relationshipsとして中間テーブルを明示
+  # source: :followとして、relationshipsテーブルのfollow_idを参考にして、followingsモデルにアクセスするよう明示
+  has_many :followings, through: :relationships, source: :follow
+  # reverse_of_relationshipsクラス（model）は存在しないため、class_name: 'Relationshipとしてrelationsipモデルの事だと明示
+  # foreign_key: 'follow_id'とすることでrelaitonshipsテーブルにアクセスする時、follow_idを使うよう明示
+  has_many :reverse_of_relationships, class_name: 'Relationship', foreign_key: 'follow_id'
+  # followersクラス（model）は存在しないため、through: :reverses_of_relationshipとして中間テーブルを明示
+  # source: :userとして、user_idを参考にするよう明示
+  has_many :followers, through: :reverse_of_relationships, source: :user
+
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,
          :confirmable, :lockable, :timeoutable, :trackable, :omniauthable, omniauth_providers:[:twitter]
+
+  def follow(other_user)
+    unless self == other_user
+      self.relationships.find_or_create_by(follow_id: other_user.id)
+    end
+  end
+
+  def unfollow(other_user)
+    relationship = self.relationships.find_by(follow_id: other_user.id)
+    relationship.destroy if relationship
+  end
+
+  def following?(other_user)
+    self.followings.include?(other_user)
+  end
 end

--- a/app/views/relationships/_follow_button.html.erb
+++ b/app/views/relationships/_follow_button.html.erb
@@ -1,0 +1,13 @@
+<% unless current_user == user %>
+  <% if current_user.following?(user) %>
+    <%= form_for(current_user.relationships.find_by(follow_id: user.id), html: { method: :delete }) do |f| %>
+      <%= hidden_field_tag :follow_id, user.id %>
+      <%= f.submit 'Unfollow', class: 'btn btn-danger btn-block' %>
+    <% end %>
+  <% else %>
+    <%= form_for(current_user.relationships.build) do |f| %>
+      <%= hidden_field_tag :follow_id, user.id %>
+      <%= f.submit 'Follow', class: 'btn btn-primary btn-block' %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/user/index.html.erb
+++ b/app/views/user/index.html.erb
@@ -1,8 +1,9 @@
 <h1>ユーザ一覧</h1>
 
 <% @users.each do |user| %>
-  <tr>
-    <td><%= user.id %></td> 
-    <td><%= user.username %></td> 
-  </tr>
+  <ul>
+    <li>ユーザID：<%= user.id %></li> 
+    <li>ユーザ名：<%= user.username %></li>
+    <li><%= render 'relationships/follow_button', user: user %></li>
+  </ul>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,4 +4,5 @@ Rails.application.routes.draw do
   root to: "top#index"
   get 'top/index'
   get 'top/show'
+  resources :relationships, only: [:create, :destroy]
 end

--- a/db/migrate/20200915142037_create_relationships.rb
+++ b/db/migrate/20200915142037_create_relationships.rb
@@ -1,0 +1,12 @@
+class CreateRelationships < ActiveRecord::Migration[6.0]
+  def change
+    create_table :relationships do |t|
+      t.references :user, foreign_key: true
+      t.references :follow, foreign_key: { to_table: :users }
+
+      t.timestamps
+
+      t.index [:user_id, :follow_id], unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,31 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_15_055825) do
+ActiveRecord::Schema.define(version: 2020_09_15_142037) do
+
+  create_table "follows", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "followable_type", null: false
+    t.bigint "followable_id", null: false
+    t.string "follower_type", null: false
+    t.bigint "follower_id", null: false
+    t.boolean "blocked", default: false, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["followable_id", "followable_type"], name: "fk_followables"
+    t.index ["followable_type", "followable_id"], name: "index_follows_on_followable_type_and_followable_id"
+    t.index ["follower_id", "follower_type"], name: "fk_follows"
+    t.index ["follower_type", "follower_id"], name: "index_follows_on_follower_type_and_follower_id"
+  end
+
+  create_table "relationships", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "follow_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["follow_id"], name: "index_relationships_on_follow_id"
+    t.index ["user_id", "follow_id"], name: "index_relationships_on_user_id_and_follow_id", unique: true
+    t.index ["user_id"], name: "index_relationships_on_user_id"
+  end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -41,4 +65,6 @@ ActiveRecord::Schema.define(version: 2020_09_15_055825) do
     t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true
   end
 
+  add_foreign_key "relationships", "users"
+  add_foreign_key "relationships", "users", column: "follow_id"
 end


### PR DESCRIPTION
## フォロー機能の実装

参考；
https://qiita.com/mitsumitsu1128/items/e41e2ff37f143db81897


```
⓵relationshipsモデルを作る
⓶relationshipsのマイグレーションファイルを編集&実行
⓷userモデルとrelationshipsモデルにアソシエーションを書く
⓸userモデルにフォロー機能のメソッドを書く
⓹relationshipsコントローラを作成&編集
⓺フォローボタン（form_for）をviewに設置
⓻ルーティングを書く

```
### migrationファイルについて

relationshipsテーブルは中間テーブルなので、user_idとfollow_idは「t.references」で作ってあげる必要がある。
外部キーとしての設定をするためにオプションは「foreign_key: true」とする。

注意※ follow_idの参照先のテーブルはusersテーブルにしてあげたいので、{to_table: :users}としている。
foreign_key: trueにすると存在しないfollowsテーブルを参照してしまうので。。

t.index [:user_id, :follow_id], unique: true は、 user_id と follow_id のペアで重複するものが保存されないようにするデータベースの設定。これは、あるユーザがあるユーザをフォローしたとき、フォローを解除せずに、重複して何度もフォローできてしまうような事態を防いでいるだけ。


### Relationship_modelアソシエーション
class_name: ‘User’ と補足設定することで、Followクラスという存在しないクラスを参照することを防ぎ、User クラスであることを明示している。「followモデルなんて存在しないので、userモデルにbelongs_toしてね！」ということ。


### User_modelアソシエーション
１行目のhas_many :relationshipsは通常通り
2行目のhas_many :followingsはfollowingクラス（モデル）を架空で作成。
followingクラス（モデル）なんて存在しないため、補足を付け足す必要があります。
through: :relationships は「中間テーブルはrelationshipsだよ」って設定してあげてるだけです。
source: :followとすることで「relationshipsテーブルのfollow_idを参考にして、followingsモデルにアクセスしてね」と明示。
結果として、user.followings と打つだけで、user が中間テーブル relationships を取得し、その1つ1つの relationship のfollow_idから、「フォローしている User 達」を取得している。

次にフォロワー（フォローされているuser達）をとってくるための記述。
3行目のhas_many :reverse_of_relationshipsは
has_many :relaitonshipsの「逆方向」って意味。
reverse_of_relationshipsなんて中間テーブルは存在しません。なので、これも補足を付け足す。
class_name: 'Relationship'で「relationsipモデルの事だよ〜」と設定してあげる。

次のforeign_key: 'follow_id'、「relaitonshipsテーブルにアクセスする時、follow_idを入口として来てね！」っていう事。

user_idを入口として、relationshipsテーブルという家に「おじゃましま〜す」と入って、follow_idという出口（＝source: :follow）から出て、followingsテーブルからフォローしている人のデータをとってくるイメージ！

foregin_key = 入口
source = 出口

４行目。
followersなんてクラス存在しないため、
through: :reverses_of_relationshipで「中間テーブルはreverses_of_relationshipにしてね」と設定し、
source: :userで「出口はuser_idね！それでuserテーブルから自分をフォローしているuserをとってきてね！」と設定している。